### PR TITLE
bluetooth: Our kernel is missing CLOCK_BOOTTIME_ALARM (alarmtimer)

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -29,4 +29,7 @@
 #define BLE_PERIPHERAL_ADV_NAME  FALSE
 #define BT_CLEAN_TURN_ON_DISABLED 1
 
+/* Defined if the kernel does not have support for CLOCK_BOOTTIME_ALARM */
+#define KERNEL_MISSING_CLOCK_BOOTTIME_ALARM TRUE
+
 #endif


### PR DESCRIPTION
* Kernel is still using drivers/rtc/alarm.c, instead of the newer
  kernel/time/alarmtimer.c

This is what kept giving me errors using your candy kernel.